### PR TITLE
Add new toggle and populate

### DIFF
--- a/admin_page.php
+++ b/admin_page.php
@@ -59,6 +59,8 @@ if (!isset($_GET["data_select"])) {
         // displays switch for toggling active vs inactive if dreamer is selected
         if ($_GET["data_select"] == "dreamers") { ?>
             <div class="switch-field">
+                <input type="radio" id="pending-dreamer" name="switch-one" value="Pending"/>
+                <label id="pending-dreamer-label" for="pending-dreamer">Pending</label>
                 <input type="radio" id="active-dreamer" name="switch-one" value="Active" checked/>
                 <label id="active-dreamer-label" for="active-dreamer">Active</label>
                 <input type="radio" id="inactive-dreamer" name="switch-one" value="Inactive" />

--- a/private/ajax_functions.php
+++ b/private/ajax_functions.php
@@ -121,6 +121,20 @@ if (isset($_POST['queryType'])) {
         $result_ids = mysqli_query($db, $sql_ids);
 
         echo buildTable($result, $tableHeadingNames, $result_ids);
+    } else if($_POST['queryType'] == 'pending_query') {
+        // Selects and returns output string containing table with inactive users
+        global $db;
+
+        $sql = "SELECT user_first, user_last, user_email, user_phone, dreamer_date_of_birth, dreamer_active, user_date_joined FROM User 
+                INNER JOIN Dreamer ON User.user_id = Dreamer.user_id
+                WHERE dreamer_active = 'pending';";
+        $sql_ids = "SELECT user_id FROM Dreamer WHERE dreamer_active = 'pending';";
+
+        $result = mysqli_query($db, $sql);
+        $tableHeadingNames = $result->fetch_fields();
+        $result_ids = mysqli_query($db, $sql_ids);
+
+        echo buildTable($result, $tableHeadingNames, $result_ids);
     } else if ($_POST['queryType'] == 'active_query') {
         // Selects and returns output string containing table with inactive users
         global $db;

--- a/scripts/admin_page_functions.js
+++ b/scripts/admin_page_functions.js
@@ -157,6 +157,27 @@ document.getElementById("data-select").addEventListener("change", function () {
 }); //addEventListener
 
 $(document).ready(function () {
+    // three toggle switch for Dreamers: Pending
+    $("#pending-dreamer-label").on("click", function () {
+        // make ajax call to update the display of pending volunteers
+        $.ajax({
+            url: 'private/init.php',
+            method: 'post',
+            data: {queryType: "pending_query"},
+            success: function (response) {
+                $("#dreamer-table").html(response);
+            }
+        }); //.ajax
+
+        // need to re-update the click events on the page
+        $(document).ajaxComplete(function () {
+            addClickEvents();
+            $("#dreamer-table").DataTable().destroy();
+            $("#dreamer-table").DataTable();
+        }); //.ajaxComplete
+    }); //.on
+
+    // three toggle switch for Dreamers: Active
     $("#active-dreamer-label").on("click", function () {
         // make ajax call to update the display of pending volunteers
         $.ajax({
@@ -176,6 +197,7 @@ $(document).ready(function () {
         }); //.ajaxComplete
     }); //.on
 
+    // three toggle switch for Dreamers: Inactive
     $("#inactive-dreamer-label").on("click", function () {
         // make ajax call to update the display of pending volunteers
         $.ajax({


### PR DESCRIPTION
Added three toggle to dreamers link on Admin page. It is set up the same way as the volunteer link is. The dreamers will auto display only active dreamers, and then the admin user can use the toggle to switch between sections of pending or inactive dreamers.