### PR TITLE
Modal dismiss delete

### DIFF
--- a/scripts/admin_page_functions.js
+++ b/scripts/admin_page_functions.js
@@ -432,9 +432,16 @@ $(document).ready(function () {
                 method: 'post',
                 data: {queryType: "delete", user_id: id},
                 success: function (response) {
-                    console.log($("#" + id));
-                    // removes item from the table TODO doesn't work unless the user is active for some reason
-                    $("#" + id).remove();
+                    // console.log($("#" + id));
+                    // removes item from the table
+                    let table = $("#dreamer-table").DataTable();
+                    table
+                        .row("#" + id)
+                        .remove()
+                        .draw();
+
+                    // close the modal since the user at this point will have been deleted
+                    $("#myModal").modal("toggle");
                 }
             }); //.ajax
         } // end confirm


### PR DESCRIPTION
When a dreamer or volunteer is successfully deleted the modal with their information is dismissed and their row is taken out of the jQuery data table and redrawn. ONLY happens on successful delete.